### PR TITLE
Open ssl 3.5.0

### DIFF
--- a/src/rnd_man.cc
+++ b/src/rnd_man.cc
@@ -4,20 +4,31 @@
 
 namespace rnd {
 
-RandManager::RandManager(int buff_size) : buff_size_(buff_size) {}
+RandManager::RandManager(int buff_size) : buff_size_(buff_size), 
+          mdctx_(EVP_MD_CTX_new(), EVP_MD_CTX_free) {
+  if(!mdctx_)
+    throw std::runtime_error("Failed to create EVP_MD_CTX");
+ }
 
-void RandManager::Begin() { SHA512_Init(&sha_ctx_); }
+void RandManager::Begin() {
+  if (EVP_DigestInit_ex(mdctx_.get(), EVP_sha512(), nullptr) != 1)
+    throw std::runtime_error("EVP_DigestInit_ex failed");
+}
 
 std::vector<uint8_t> RandManager::End() {
-  SHA512_Final(md_, &sha_ctx_);
-  std::vector<uint8_t> result;
-  result.resize(buff_size_);
-  std::memcpy(result.data(), md_, buff_size_);
+  unsigned int md_len = 0;
+  md_.resize(EVP_MD_size(EVP_sha512()));
+  if (EVP_DigestFinal_ex(mdctx_.get(), md_.data(), &md_len) != 1)
+    throw std::runtime_error("EVP_DigestFinal_ex failed");
+  
+  std::vector<uint8_t> result(buff_size_);
+  std::memcpy(result.data(), md_.data(), buff_size_);
   return result;
 }
 
 void RandManager::HashBuff(const uint8_t *buff, int size) {
-  SHA512_Update(&sha_ctx_, buff, size);
+  if (EVP_DigestUpdate(mdctx_.get(), buff, size) != 1)
+    throw std::runtime_error("EVP_DigestUpdate failed");
 }
 
 }  // namespace rnd

--- a/src/rnd_man.h
+++ b/src/rnd_man.h
@@ -2,9 +2,11 @@
 #define __RND_MAN_H__
 
 #include <cstdint>
+#include <memory>
 #include <vector>
+#include <stdexcept>
 
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 
 namespace rnd {
 
@@ -46,8 +48,10 @@ class RandManager {
 
  private:
   int buff_size_;
-  SHA512_CTX sha_ctx_;
-  uint8_t md_[SHA512_DIGEST_LENGTH];
+  //EVP_MD_CTX sha_ctx_;
+  //uint8_t md_[SHA512_DIGEST_LENGTH];
+  std::shared_ptr<EVP_MD_CTX> mdctx_;
+  std::vector<uint8_t> md_;
 };
 
 }  // namespace rnd

--- a/test/test.cc
+++ b/test/test.cc
@@ -19,11 +19,22 @@ const char *STRING = "Hello world!";
  * @return Hash value.
  */
 std::vector<uint8_t> Hash(const std::string &str) {
-  SHA512_CTX ctx;
-  SHA512_Init(&ctx);
-  SHA512_Update(&ctx, str.c_str(), str.size());
-  std::vector<uint8_t> md(SHA512_DIGEST_LENGTH);
-  SHA512_Final(md.data(), &ctx);
+  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+  if (!ctx)
+    throw std::runtime_error("EVP_MD_CTX_new failed");
+
+  std::vector<uint8_t> md(EVP_MD_size(EVP_sha512()));
+  unsigned int md_len = 0;
+
+  if (EVP_DigestInit_ex(ctx, EVP_sha512(), nullptr) != 1 ||
+      EVP_DigestUpdate(ctx, str.data(), str.size()) != 1 ||
+      EVP_DigestFinal_ex(ctx, md.data(), &md_len) != 1) {
+    EVP_MD_CTX_free(ctx);
+    throw std::runtime_error("Hashing failed");
+  }
+
+  EVP_MD_CTX_free(ctx);
+  md.resize(md_len);
   return md;
 }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -1,4 +1,4 @@
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 
 #include <cstdint>
 #include <string>


### PR DESCRIPTION
Replaced direct usage of SHA512_Init, SHA512_Update, and SHA512_Final with the recommended EVP_Digest* functions to comply with OpenSSL 3.0 deprecation warnings. Updated includes from <openssl/sha.h> to <openssl/evp.h>. This improves compatibility with future OpenSSL versions and follows best practices.